### PR TITLE
Adds support for mongoURL based connections

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -166,6 +166,8 @@ var MongoDatabank = function(params) {
                 }
             });
         }
+    } else if (_.has(params, "mongoUrl")) {
+        bank.mongoUrl = params.mongoUrl;
     } else {
         bank.host = params.host || 'localhost';
         bank.port = params.port || 27017;
@@ -194,7 +196,21 @@ var MongoDatabank = function(params) {
 
     if (bank.mongoUrl) {
         bank.connect = function(params, callback) {
-            Db.connect(bank.mongoUrl, bank.serverOptions, callback);
+            Step(
+                function() {
+                    Db.connect(bank.mongoUrl, bank.serverOptions, this);
+                },
+                function(err, newDb) {
+                    if (err) throw err;
+                    bank.db = newDb;
+                    if (bank.checkSchema) {
+                        checkBankSchema(callback);
+                    } else {
+                        this(null);
+                    }
+                },
+                callback
+            );
         }
     } else {
         bank.connect = function(params, callback) {


### PR DESCRIPTION
This is required for Heroku, since they communicate your mongodb details via a single MONGOLAB_URL env variable.
