### PR TITLE
Support for mongo URLs (required for Heroku)

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -166,6 +166,8 @@ var MongoDatabank = function(params) {
                 }
             });
         }
+    } else if (_.has(params, "mongoUrl")) {
+        bank.mongoUrl = params.mongoUrl;
     } else {
         bank.host = params.host || 'localhost';
         bank.port = params.port || 27017;
@@ -194,7 +196,21 @@ var MongoDatabank = function(params) {
 
     if (bank.mongoUrl) {
         bank.connect = function(params, callback) {
-            Db.connect(bank.mongoUrl, bank.serverOptions, callback);
+            Step(
+                function() {
+                    Db.connect(bank.mongoUrl, bank.serverOptions, this);
+                },
+                function(err, newDb) {
+                    if (err) throw err;
+                    bank.db = newDb;
+                    if (bank.checkSchema) {
+                        checkBankSchema(callback);
+                    } else {
+                        this(null);
+                    }
+                },
+                callback
+            );
         }
     } else {
         bank.connect = function(params, callback) {


### PR DESCRIPTION
This change enables support for mongo URLs provided Db.connect().

My earlier pull request was incomplete. This code actually works. Really I should write some tests though.
